### PR TITLE
fix HTTPSConnection Params for python 3

### DIFF
--- a/src/dogecoinrpc/proxy.py
+++ b/src/dogecoinrpc/proxy.py
@@ -61,7 +61,7 @@ class HTTPTransport(object):
         self.auth_header = "Basic ".encode("utf8") + base64.b64encode(authpair)
         if self.parsed_url.scheme == "https":
             self.connection = httplib.HTTPSConnection(
-                self.parsed_url.hostname, port, None, None, False, HTTP_TIMEOUT
+                self.parsed_url.hostname, port, None, None, HTTP_TIMEOUT
             )
         else:
             self.connection = httplib.HTTPConnection(


### PR DESCRIPTION
According to the Python 3 document:  
https://docs.python.org/3.11/library/http.client.html?highlight=httpsconnection#http.client.HTTPSConnection  
The False param should not be there, otherwise it will report error:  
TypeError: bind(): AF_INET address must be tuple, not int